### PR TITLE
Build image from Alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 install:
   - docker build -t askomics .
   - docker pull xgaia/virtuoso
-  - docker-compose -f tests/docker-compose.yml up
+  - docker-compose -d -f tests/docker-compose.yml up
 script:
   - sleep 30
   - "curl -v -H \"X-Requested-With: XMLHttpRequest\" -X GET -u http://localhost:6543/startpoints"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+services:
+  - docker
+install:
+  - docker build -t askomics .
+  - docker pull xgaia/virtuoso
+  - docker run -p 8890:8890 --name test_virtuoso xgaia/virtuoso 
+  - docker run -p 6543:6543 --name test_askomics askomics
+script:
+  - docker ps | grep -q test_askomics
+  - curl http://localhost:6543

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ services:
 install:
   - docker build -t askomics .
   - docker pull xgaia/virtuoso
-  - docker-compose -d -f tests/docker-compose.yml up
+  - docker-compose -f tests/docker-compose.yml up -d
+before_script:
+   - sleep 45
 script:
-  - sleep 30
   - "curl -v -H \"X-Requested-With: XMLHttpRequest\" -X GET -u http://localhost:6543/startpoints"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+sudo: required
 services:
   - docker
 install:
   - docker build -t askomics .
   - docker pull xgaia/virtuoso
-  - docker run -p 8890:8890 --name test_virtuoso xgaia/virtuoso 
-  - docker run -p 6543:6543 --name test_askomics askomics
+  - docker-compose -f tests/docker-compose.yml up
 script:
-  - docker ps | grep -q test_askomics
-  - curl http://localhost:6543
+  - sleep 30
+  - "curl -v -H \"X-Requested-With: XMLHttpRequest\" -X GET -u http://localhost:6543/startpoints"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 before_script:
    - sleep 45
 script:
-  - "curl -v -H \"X-Requested-With: XMLHttpRequest\" -X GET -u http://localhost:6543/startpoints"
+  - "curl -v -H \"X-Requested-With: XMLHttpRequest\" -X GET http://localhost:6543/startpoints"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,22 @@
-FROM ubuntu
+FROM alpine
 MAINTAINER Olivier Filangi "olivier.filangi@inra.fr"
 
-ENV ASKOMICS=https://github.com/askomics/askomics.git
-
 # Prerequisites
-RUN apt-get update && apt-get install -y \
-  git \
-  build-essential \
-  python3 \
-  python3-pip \
-  python3-venv \
-  vim \
-  ruby \
-  npm \
-  nodejs-legacy
+RUN apk add --update bash make gcc g++ zlib-dev libzip-dev bzip2-dev xz-dev git python3 python3-dev nodejs nodejs-npm
 
-RUN git config --global http.sslVerify false
+ENV ASKOMICS=https://github.com/askomics/askomics.git
+# ENV ASKOMICS_COMMIT=ff0a21d465f172715cbcbd71d3e87f2016bb4a01
+
 RUN git clone $ASKOMICS /usr/local/askomics/
-
 WORKDIR /usr/local/askomics/
+# RUN git checkout $ASKOMICS_COMMIT
 
 RUN npm install gulp -g
 RUN npm install
-RUN chmod +x startAskomics.sh
 
-# Delete the local venv if exist and build the new one
-RUN rm -rf /usr/local/askomics/venv && \
-    ./startAskomics.sh -b
+RUN chmod +x startAskomics.sh
+RUN rm -rf /usr/local/askomics/venv
+RUN bash ./startAskomics.sh -b
 
 EXPOSE 6543
-CMD ["./startAskomics.sh", "-r"]
+CMD ["bash", "./startAskomics.sh", "-r"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,23 @@
 FROM alpine
 MAINTAINER Olivier Filangi "olivier.filangi@inra.fr"
 
-# Prerequisites
-RUN apk add --update bash make gcc g++ zlib-dev libzip-dev bzip2-dev xz-dev git python3 python3-dev nodejs nodejs-npm
+# Environment variables
+ENV ASKOMICS="https://github.com/askomics/askomics.git" \
+    ASKOMICS_DIR="/usr/local/askomics"
+#ENV ASKOMICS_COMMIT ff0a21d465f172715cbcbd71d3e87f2016bb4a01
 
-ENV ASKOMICS=https://github.com/askomics/askomics.git
-# ENV ASKOMICS_COMMIT=ff0a21d465f172715cbcbd71d3e87f2016bb4a01
+# Install prerequisites, clone repository and install
+RUN apk add --update bash make gcc g++ zlib-dev libzip-dev bzip2-dev xz-dev git python3 python3-dev nodejs nodejs-npm && \
+    git clone ${ASKOMICS} ${ASKOMICS_DIR} && \
+    cd ${ASKOMICS_DIR} && \
+    #git checkout ${ASKOMICS_COMMIT} && \
+    npm install gulp -g && \
+    npm install && \
+    chmod +x startAskomics.sh && \
+    rm -rf /usr/local/askomics/venv && \
+    bash ./startAskomics.sh -b
 
-RUN git clone $ASKOMICS /usr/local/askomics/
 WORKDIR /usr/local/askomics/
-# RUN git checkout $ASKOMICS_COMMIT
-
-RUN npm install gulp -g
-RUN npm install
-
-RUN chmod +x startAskomics.sh
-RUN rm -rf /usr/local/askomics/venv
-RUN bash ./startAskomics.sh -b
 
 EXPOSE 6543
 CMD ["bash", "./startAskomics.sh", "-r"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,17 @@ MAINTAINER Olivier Filangi "olivier.filangi@inra.fr"
 # Environment variables
 ENV ASKOMICS="https://github.com/askomics/askomics.git" \
     ASKOMICS_DIR="/usr/local/askomics"
-#ENV ASKOMICS_COMMIT ff0a21d465f172715cbcbd71d3e87f2016bb4a01
 
 # Install prerequisites, clone repository and install
 RUN apk add --update bash make gcc g++ zlib-dev libzip-dev bzip2-dev xz-dev git python3 python3-dev nodejs nodejs-npm && \
-    git clone ${ASKOMICS} ${ASKOMICS_DIR} && \
+    git clone --depth=1 ${ASKOMICS} ${ASKOMICS_DIR} && \
     cd ${ASKOMICS_DIR} && \
-    #git checkout ${ASKOMICS_COMMIT} && \
     npm install gulp -g && \
-    npm install && \
+    npm install --production && \
     chmod +x startAskomics.sh && \
     rm -rf /usr/local/askomics/venv && \
-    bash ./startAskomics.sh -b
+    bash ./startAskomics.sh -b && \
+    rm -rf /var/cache/apk/*
 
 WORKDIR /usr/local/askomics/
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # docker-askomics
+
+![Docker Build](https://img.shields.io/docker/pulls/askomics/docker-askomics.svg)
+
 AskOmics dockerized
+
+## Pull from dockerHub
+
+    docker pull askomics/docker-askomics
+
+## Or build
+
+    # Clone the repo
+    git clone https://github.com/askomics/askomics.git
+    cd askomics
+    docker build -t askomics .
+
+## Run
+
+    docker run --name myAskOmics \
+        -p 6543:6543 \
+        d askomics/docker-askomics

--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ AskOmics dockerized
     docker run --name myAskOmics \
         -p 6543:6543 \
         d askomics/docker-askomics
+
+
+## .ini configuration
+
+All askomics properties defined in section [app:main] of the .ini file can be configured via the environment variables. The environment variable should be prefixed with ASKO_, without the askomics.
+
+For exemple, if ou want to modify `askomics.overview_lines_limit = 200` of the ini file, you must declare a environment variable like `ASKO_overview_lines_limit="1000"`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # docker-askomics
 
 ![Docker Build](https://img.shields.io/docker/pulls/askomics/docker-askomics.svg)
+[![Build Status](https://travis-ci.org/askomics/docker-askomics.svg?branch=master)](https://travis-ci.org/askomics/docker-askomics)
 
 AskOmics dockerized
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+    askomics:
+        image: askomics
+        command: ./startAskomics.sh -r -t virtuoso -d dev
+        environment:
+            TRIPLESTORE_ENDPOINT: "http://virtuoso:8890/sparql"
+            ASKOMICS_LOAD_URL: "http://askomics:6543"
+            TRIPLESTORE_ENDPOINT_USERNAME : dba
+            TRIPLESTORE_ENDPOINT_PASSWD : dba
+        ports:
+            - "6543:6543"
+    virtuoso:
+        image: xgaia/virtuoso
+        environment:
+            SPARQL_UPDATE: "true"
+            DBA_PASSWORD: "dba"
+            DEFAULT_GRAPH: "http://localhost:8890/DAV"


### PR DESCRIPTION
## Image optimisation 

Before: 891 MB

- Use Alpine: 632 MB
- All install command in one RUN: 628 MB
- Remove /var/cache/apk: 627 MB
- Intall only production npm packages: 480 MB

**411 MB of economy**

## Readme

README.md with installation instruction and a badge to show the number of pulls